### PR TITLE
Add GitHub Actions workflow for CI testing

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
-      RUN_AS: 1001:121
+      WORKSPACE: /github/workspace/
+      QUICKLISP_DIST_VERSION: 2022-02-20
+      QUICKLISP_ADD_TO_INIT_FILE: true
     # Service containers to run with `container-job`
     services:
       # Label used to access the service container
@@ -14,8 +16,8 @@ jobs:
         image: postgres
         # Provide the password for postgres
         env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: migratum
+          POSTGRES_PASSWORD: FvbRd5qdeWHNum9p
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -27,6 +29,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Test
-        uses: docker://mcreations/sbcl:2.1.1-ql-2021-04-11
+        uses: docker://clfoundation/sbcl:2.2.1
         with:
-          args: --eval "(push \"/github/workspace/\" asdf:*central-registry*)" --eval "(ql:quickload :cl-migratum.test)" --eval "(setf rove:*enable-colors* nil)" --eval "(asdf:test-system :cl-migratum.test)" --eval "(sb-ext:exit :code (length (rove/core/stats:all-failed-assertions rove/core/stats:*stats*)))"
+          args: /github/workspace/bin/run-ci-tests.sh

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,32 @@
+# .github/workflows/test.yaml
+name: test
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      RUN_AS: 1001:121
+    # Service containers to run with `container-job`
+    services:
+      # Label used to access the service container
+      postgres:
+        # Docker Hub PostgreSQL image
+        image: postgres
+        # Provide the password for postgres
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # Maps tcp port 5432 on service container to the host
+          - 5432:5432
+    steps:
+      - uses: actions/checkout@v2
+      - name: Test
+        uses: docker://mcreations/sbcl:2.1.1-ql-2021-04-11
+        with:
+          args: --eval "(push \"/github/workspace/\" asdf:*central-registry*)" --eval "(ql:quickload :cl-migratum.test)" --eval "(setf rove:*enable-colors* nil)" --eval "(asdf:test-system :cl-migratum.test)" --eval "(sb-ext:exit :code (length (rove/core/stats:all-failed-assertions rove/core/stats:*stats*)))"

--- a/bin/run-ci-tests.sh
+++ b/bin/run-ci-tests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+/usr/local/bin/install-quicklisp
+
+# configure ASDF to find our files in $WORKSPACE
+mkdir -p ~/.config/common-lisp/source-registry.conf.d/
+echo "(:tree \"${WORKSPACE}\")" > ~/.config/common-lisp/source-registry.conf.d/workspace.conf
+
+exec "${WORKSPACE}/entrypoint.sh" "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-sbcl --eval '(ql:quickload :cl-migratum.test)' \
+sbcl --non-interactive --eval '(ql:quickload :cl-migratum.test)' \
      --eval '(setf rove:*enable-colors* nil)' \
      --eval '(asdf:test-system :cl-migratum.test)' \
-     --eval '(quit)'
+     --eval '(uiop:quit (length (rove/core/stats:all-failed-assertions rove/core/stats:*stats*)))'


### PR DESCRIPTION
The tests are run in an SBCL container which I will update to the
latest SBCL and Quicklisp shortly.

The workflow also starts a PostgreSQL service container which is
not (yet) used. 
