### PR TITLE
Add rdbms-postgresql driver which uses hu.dwim.rdbms

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,11 +1,17 @@
 # .github/workflows/test.yaml
 name: test
-on: push
+on: [ push, pull_request ]
 jobs:
   test:
     runs-on: ubuntu-latest
     env:
       WORKSPACE: /github/workspace/
+      # the env vars for the PostgreSQL connection must be in sync
+      # with the 'postgres' service below
+      PGHOST: postgres
+      PGDATABASE: migratum
+      PGUSER: migratum
+      PGPASSWORD: FvbRd5qdeWHNum9p
       QUICKLISP_DIST_VERSION: 2022-02-20
       QUICKLISP_ADD_TO_INIT_FILE: true
     # Service containers to run with `container-job`

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 # Emacs backup files
 *~
+\#*
+.\#*
+
+# lisp junk
+*.FASL
+*.fasl
+*.lisp-temp

--- a/cl-migratum.driver.rdbms-postgresql.asd
+++ b/cl-migratum.driver.rdbms-postgresql.asd
@@ -1,0 +1,23 @@
+(defpackage :cl-migratum-driver-rdbms-postgresql-system
+  (:use :cl :asdf))
+(in-package :cl-migratum-driver-rdbms-postgresql-system)
+
+(defsystem "cl-migratum.driver.rdbms-postgresql"
+  :name "cl-migratum.driver.rdbms-postgresql"
+  :description "cl-migratum driver for driving migrations against SQL databases using hu.dwim.rdbms.postgresql"
+  :version "0.3.0"
+  :author "Marin Atanasov Nikolov <dnaeon@gmail.com>"
+  :maintainer "Marin Atanasov Nikolov <dnaeon@gmail.com>"
+  :license "BSD-2 Clause"
+  :homepage "https://github.com/dnaeon/cl-migratum"
+  :bug-tracker "https://github.com/dnaeon/cl-migratum"
+  :source-control "https://github.com/dnaeon/cl-migratum"
+  :long-name "cl-migratum.driver.rdbms-postgresql"
+  :depends-on (:cl-migratum
+               :cl-ppcre
+               :hu.dwim.logger
+               :hu.dwim.rdbms.postgresql
+               :log4cl)
+  :components ((:module "driver"
+                :pathname #P"src/driver/"
+                :components ((:file "rdbms-postgresql")))))

--- a/cl-migratum.driver.rdbms-postgresql.asd
+++ b/cl-migratum.driver.rdbms-postgresql.asd
@@ -5,8 +5,8 @@
 (defsystem "cl-migratum.driver.rdbms-postgresql"
   :name "cl-migratum.driver.rdbms-postgresql"
   :description "cl-migratum driver for driving migrations against SQL databases using hu.dwim.rdbms.postgresql"
-  :version "0.3.0"
-  :author "Marin Atanasov Nikolov <dnaeon@gmail.com>"
+  :version "0.1.0"
+  :author ("Marin Atanasov Nikolov <dnaeon@gmail.com>" "Kambiz Darabi <darabi@m-creations.net>")
   :maintainer "Marin Atanasov Nikolov <dnaeon@gmail.com>"
   :license "BSD-2 Clause"
   :homepage "https://github.com/dnaeon/cl-migratum"

--- a/cl-migratum.test.asd
+++ b/cl-migratum.test.asd
@@ -16,6 +16,7 @@
   :depends-on (:cl-migratum
                :cl-migratum.provider.local-path
                :cl-migratum.driver.dbi
+               :cl-migratum.driver.rdbms-postgresql
                :dbd-sqlite3
                :tmpdir
                :rove)
@@ -32,5 +33,8 @@
                (:module "tests"
                 :pathname #P"t/"
                 :depends-on ("test-migrations")
-                :components ((:file "test-suite"))))
+                :components ((:file "test-suite")
+                             (:file "local-path-provider")
+                             (:file "dbi-driver")
+                             (:file "rdbms-postgresql-driver"))))
   :perform (test-op (op c) (uiop:symbol-call :rove :run-suite :cl-migratum.test)))

--- a/src/driver/rdbms-postgresql.lisp
+++ b/src/driver/rdbms-postgresql.lisp
@@ -1,0 +1,172 @@
+;; Copyright (c) 2020-2022 Marin Atanasov Nikolov <dnaeon@gmail.com>
+;; All rights reserved.
+;;
+;; Redistribution and use in source and binary forms, with or without
+;; modification, are permitted provided that the following conditions
+;; are met:
+;;
+;;  1. Redistributions of source code must retain the above copyright
+;;     notice, this list of conditions and the following disclaimer
+;;     in this position and unchanged.
+;;  2. Redistributions in binary form must reproduce the above copyright
+;;     notice, this list of conditions and the following disclaimer in the
+;;     documentation and/or other materials provided with the distribution.
+;;
+;; THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+;; IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+;; OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+;; IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+;; INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+;; NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+;; DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+;; THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+;; (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+;; THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+(in-package :cl-user)
+(defpackage :cl-migratum.driver.rdbms-postgresql
+  (:use :cl)
+  (:nicknames :migratum.driver.rdbms-postgresql)
+  (:import-from
+   :cl-migratum
+   :base-migration
+   :migration-id
+   :migration-description
+   :migration-load-up-script
+   :migration-load-down-script
+   :base-driver
+   :driver-name
+   :driver-provider
+   :driver-init
+   :driver-shutdown
+   :driver-initialized
+   :driver-list-applied
+   :driver-apply-up-migration
+   :driver-apply-down-migration
+   :driver-register-migration
+   :driver-unregister-migration)
+  (:import-from :log)
+  (:import-from :hu.dwim.logger
+   :+warn+
+   :set-log-level)
+  (:import-from :hu.dwim.rdbms.postgresql)
+  (:import-from :cl-ppcre)
+  (:export
+   :rdbms-postgresql-driver
+   :make-driver))
+(in-package :cl-migratum.driver.rdbms-postgresql)
+
+(defparameter *sql-statement-separator*
+  "--;;"
+  "Separator to use when splitting a migration into multiple statements")
+
+(defparameter *sql-init-schema*
+  "
+CREATE TABLE IF NOT EXISTS migration (
+    id BIGINT PRIMARY KEY,
+    description CHARACTER VARYING(255) NOT NULL,
+    applied TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);"
+  "Schema used by the SQL driver")
+
+(defclass rdbms-postgresql-driver (base-driver)
+  ((database
+    :initarg :database
+    :accessor database-of
+    :initform nil
+    :documentation "hu.dwim.rdbms database to use")
+   (connection-specification
+    :initarg :connection-specification
+    :accessor connection-specification-of
+    :initform (error "Must specify database connection specification")
+    :documentation "Connection specification for hu.dwim.rdbms e.g. (:host \"localhost\" :port 5432 :database \"migratum\" :user-name \"migratum_user\" :password \"changeit\" :use-ssl :yes)
+    Note that :host defaults to \"localhost\", :port to 5432, and :use-ssl to :no"))
+  (:documentation "Driver for performing SQL migrations with hu.dwim.rdbms.postgresql"))
+
+(defmethod initialize-instance :after ((-self- rdbms-postgresql-driver) &key)
+  (with-slots ((connspec connection-specification) (db database)) -self-
+    (setf db (make-instance 'hu.dwim.rdbms.postgresql:postgresql :connection-specification connspec))
+    (set-log-level 'hu.dwim.rdbms::rdbms +warn+)))
+
+(defmethod driver-init ((driver rdbms-postgresql-driver) &key)
+  (log:debug "Initializing ~a driver" (driver-name driver))
+  (let* ((database (database-of driver))
+         (query *sql-init-schema*))
+    (hu.dwim.rdbms:with-database database
+      (hu.dwim.rdbms:with-transaction
+        (hu.dwim.rdbms:execute query)))
+    (setf (driver-initialized driver) t)))
+
+(defmethod driver-shutdown ((driver rdbms-postgresql-driver) &key)
+  (log:debug "Shutting down ~a driver" (driver-name driver))
+  (setf (driver-initialized driver) nil))
+
+(defmethod driver-list-applied ((driver rdbms-postgresql-driver) &key (offset 0) (limit 100))
+  (log:debug "Fetching list of applied migrations")
+  (let* ((db (database-of driver))
+         (query (format nil "SELECT * FROM migration ORDER BY id DESC LIMIT ~A OFFSET ~A" limit offset))
+         (rows (hu.dwim.rdbms:with-database db (hu.dwim.rdbms:with-transaction (hu.dwim.rdbms:execute query :result-type 'list)))))
+    (mapcar (lambda (row)
+              (make-instance 'base-migration
+                             :id (nth 0 row)
+                             :description (nth 1 row)
+                             :applied (nth 2 row)))
+            rows)))
+
+(defmethod driver-register-migration ((driver rdbms-postgresql-driver) (migration base-migration) &key)
+  (log:debug "Registering migration as successful: ~a" (migration-id migration))
+  (let* ((db (database-of driver))
+         (id (migration-id migration))
+         (description (migration-description migration))
+         (query (format nil "INSERT INTO migration (id, description) VALUES (~A, '~A')" id description)))
+    (hu.dwim.rdbms:with-database db
+      (hu.dwim.rdbms:with-transaction
+        (hu.dwim.rdbms:execute query)))))
+
+(defmethod driver-unregister-migration ((driver rdbms-postgresql-driver) (migration base-migration) &key)
+  (log:debug "Unregistering migration: ~a" (migration-id migration))
+  (let* ((db (database-of driver))
+         (id (migration-id migration))
+         (query (format nil "DELETE FROM migration WHERE id = ~A" id)))
+    (hu.dwim.rdbms:with-database db
+      (hu.dwim.rdbms:with-transaction
+        (hu.dwim.rdbms:execute query)))))
+
+(defmethod driver-apply-up-migration ((driver rdbms-postgresql-driver) (migration base-migration) &key)
+  (log:debug "Applying upgrade migration: ~a - ~a" (migration-id migration) (migration-description migration))
+  (rdbms-postgresql-driver-apply-migration driver migration #'migration-load-up-script))
+
+(defmethod driver-apply-down-migration ((driver rdbms-postgresql-driver) (migration base-migration) &key)
+  (log:debug "Applying downgrade migration: ~a - ~a" (migration-id migration) (migration-description migration))
+  (rdbms-postgresql-driver-apply-migration driver migration #'migration-load-down-script))
+
+(defun make-driver (provider connection-specification)
+  "Creates a driver for performing migrations against a SQL database
+
+Arguments:
+
+  - provider: an instance of a provider (e.g. local-path)
+  - connection-specification: a connection specification as required by hu.dwim.rdbms e.g. (:host \"localhost\" :port 5432 :database \"migratum\" :user-name \"migratum_user\" :password \"changeit\" :use-ssl :yes)
+    Note that :host defaults to \"localhost\", :port to 5432, and :use-ssl to :no"
+  (make-instance 'rdbms-postgresql-driver
+                 :name "RDBMS-PG"
+                 :provider provider
+                 :connection-specification connection-specification))
+
+;; (defparameter *tstdrv* (make-driver (cl-migratum.provider.local-path:make-local-path-provider "~/common-lisp/cl-migratum/t/migrations/") '(:database "migratum" :user-name "migratum" :password "FvbRd5qdeWHNum9p")))
+
+;; (driver-init *tstdrv*)
+
+;; (cl-migratum.core:apply-pending *tstdrv*)
+;; (cl-migratum.core:display-applied *tstdrv*)
+
+(defun rdbms-postgresql-driver-apply-migration (driver migration migration-script-loader-fun)
+  "Applies the script loaded using the migration script loader function"
+  (let* ((db (database-of driver))
+         (content (funcall migration-script-loader-fun migration))
+         (statements (cl-ppcre:split *sql-statement-separator* content)))
+    (hu.dwim.rdbms:with-database db
+      (hu.dwim.rdbms:with-transaction
+        (dolist (statement statements)
+          (let ((stmt (string-trim #(#\Newline) statement)))
+            (hu.dwim.rdbms:execute stmt)))))))

--- a/src/driver/rdbms-postgresql.lisp
+++ b/src/driver/rdbms-postgresql.lisp
@@ -1,4 +1,4 @@
-;; Copyright (c) 2020-2022 Marin Atanasov Nikolov <dnaeon@gmail.com>
+;; Copyright (c) 2020-2022 Marin Atanasov Nikolov <dnaeon@gmail.com>, Kambiz Darabi <darabi@m-creations.net>
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/t/dbi-driver.lisp
+++ b/t/dbi-driver.lisp
@@ -1,0 +1,98 @@
+;; Copyright (c) 2020-2022 Marin Atanasov Nikolov <dnaeon@gmail.com>
+;; All rights reserved.
+;;
+;; Redistribution and use in source and binary forms, with or without
+;; modification, are permitted provided that the following conditions
+;; are met:
+;;
+;;  1. Redistributions of source code must retain the above copyright
+;;     notice, this list of conditions and the following disclaimer
+;;     in this position and unchanged.
+;;  2. Redistributions in binary form must reproduce the above copyright
+;;     notice, this list of conditions and the following disclaimer in the
+;;     documentation and/or other materials provided with the distribution.
+;;
+;; THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+;; IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+;; OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+;; IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+;; INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+;; NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+;; DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+;; THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+;; (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+;; THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+(in-package :cl-migratum.test)
+
+(deftest dbi-driver
+  (testing "driver-name"
+    (ok (string= "DBI" (driver-name *dbi-driver*)) "driver name matches"))
+
+  (testing "driver-initialized"
+    (ok (eq nil (driver-initialized *dbi-driver*)) "driver is not yet initialized"))
+
+  (testing "driver-init"
+    (ok (eq t (driver-init *dbi-driver*)) "initialize driver")
+    (ok (eq t (driver-initialized *dbi-driver*)) "driver is initialized"))
+
+  (testing "driver-list-applied"
+    (ng (driver-list-applied *dbi-driver*) "no migrations have been applied yet"))
+
+  (testing "contains-applied-migrations-p"
+    (ok (eq nil (contains-applied-migrations-p *dbi-driver*)) "does not contain applied migrations"))
+
+  (testing "list-pending"
+    (let ((pending (list-pending *dbi-driver*)))
+      (ok (= 4 (length pending)) "number of pending migrations matches")
+      (ok (equal (list 20200421173657 20200421173908 20200421180337 20200605144633)
+                 (mapcar #'migration-id pending))
+          "identifiers of pending migrations matches")))
+
+  (testing "apply-pending"
+    (apply-pending *dbi-driver*)
+    (let ((applied (driver-list-applied *dbi-driver*)))
+      (ok (= 4 (length applied)) "number of applied migrations matches")
+      (ok (equal (list 20200605144633 20200421180337 20200421173908 20200421173657)
+                 (mapcar #'migration-id applied))
+          "identifiers of applied migrations matches")))
+
+  (testing "pagination"
+    (ok (= 1 (length (driver-list-applied *dbi-driver* :offset 0 :limit 1)))
+        "page with :offset 0 :limit 1")
+    (ok (= 1 (length (driver-list-applied *dbi-driver* :offset 1 :limit 1)))
+        "page with :offset 1 :limit 1")
+    (ok (= 2 (length (driver-list-applied *dbi-driver* :offset 1 :limit 2)))
+        "page with :offset 1 :limit 2")
+    (ng (driver-list-applied *dbi-driver* :offset 100 :limit 100)
+        "page with :offset 100 :limit 100"))
+
+  (testing "latest-migration"
+    (ok (= 20200605144633 (migration-id (latest-migration *dbi-driver*)))
+        "latest migration id matches"))
+
+  (testing "revert-last"
+    (revert-last *dbi-driver* :count 4)
+    (ng (contains-applied-migrations-p *dbi-driver*)
+        "no migrations present after revert")
+    (ng (driver-list-applied *dbi-driver*)
+        "no migrations applied after revert"))
+
+  (testing "apply-next"
+    (ng (contains-applied-migrations-p *dbi-driver*)
+        "no migrations present yet")
+    (apply-next *dbi-driver*)
+    (ok (= 20200421173657 (migration-id (latest-migration *dbi-driver*)))
+        "id matches next applied migration")
+    (apply-next *dbi-driver*)
+    (ok (= 20200421173908 (migration-id (latest-migration *dbi-driver*)))
+        "id matches next applied migration")
+    (apply-next *dbi-driver*)
+    (ok (= 20200421180337 (migration-id (latest-migration *dbi-driver*)))
+        "id matches next applied migration")
+    (apply-next *dbi-driver*)
+    (ok (= 20200605144633 (migration-id (latest-migration *dbi-driver*)))
+        "id matches next applied migration")
+    (apply-next *dbi-driver*) ;; No more pending migrations at this point
+    (ok (= 20200605144633 (migration-id (latest-migration *dbi-driver*)))
+        "id of last migration is the same"))) ;; ID did not change, since previous migration

--- a/t/local-path-provider.lisp
+++ b/t/local-path-provider.lisp
@@ -1,0 +1,74 @@
+;; Copyright (c) 2020-2022 Marin Atanasov Nikolov <dnaeon@gmail.com>
+;; All rights reserved.
+;;
+;; Redistribution and use in source and binary forms, with or without
+;; modification, are permitted provided that the following conditions
+;; are met:
+;;
+;;  1. Redistributions of source code must retain the above copyright
+;;     notice, this list of conditions and the following disclaimer
+;;     in this position and unchanged.
+;;  2. Redistributions in binary form must reproduce the above copyright
+;;     notice, this list of conditions and the following disclaimer in the
+;;     documentation and/or other materials provided with the distribution.
+;;
+;; THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+;; IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+;; OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+;; IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+;; INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+;; NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+;; DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+;; THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+;; (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+;; THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+(in-package :cl-migratum.test)
+
+(deftest local-path-provider
+  (testing "provider-name"
+    (ok (string= "local-path" (provider-name *provider*))
+        "provider name matches"))
+
+  (testing "provider-init"
+    (ok (provider-init *provider*)
+        "initialize provider"))
+
+  (testing "provider-initialized"
+    (ok (provider-initialized *provider*)
+        "provider is initialized"))
+
+  (testing "provider-list-migrations"
+    (let* ((discovered (provider-list-migrations *provider*))
+           (migrations (sort discovered #'< :key #'migration-id)))
+      (ok (= 4 (length migrations)) "number of migrations matches")
+      (ok (equal (list 20200421173657 20200421173908 20200421180337 20200605144633)
+                 (mapcar #'migration-id migrations))
+          "identifiers of migrations matches")
+      (ok (equal (list "create_table_foo" "create_table_bar" "create_table_qux" "multiple_statements")
+                 (mapcar #'migration-description migrations))
+          "description of migrations matches")))
+
+  (testing "provider-find-migration-by-id"
+    (ok (provider-find-migration-by-id *provider* 20200421173657)
+        "find existing migration by id")
+    (ng (provider-find-migration-by-id *provider* 'no-such-id)
+        "find non-existing migration"))
+
+  (testing "provider-create-migration"
+    (let* ((migration (provider-create-migration *provider*
+                                                 :description "my-new-migration"
+                                                 :up "CREATE TABLE cl_migratum_test (id INTEGER PRIMARY KEY);"
+                                                 :down "DROP TABLE cl_migratum_test;")))
+      (ok (numberp (migration-id migration))
+          "migration id is a number")
+      (ok (string= "my_new_migration" (migration-description migration))
+          "migration description matches")
+      (ok (string= "CREATE TABLE cl_migratum_test (id INTEGER PRIMARY KEY);"
+                   (migration-load-up-script migration))
+          "upgrade script matches")
+      (ok (string= "DROP TABLE cl_migratum_test;"
+                   (migration-load-down-script migration))
+          "downgrade script matches")
+      (uiop:delete-file-if-exists (local-path-migration-up-script-path migration))
+      (uiop:delete-file-if-exists (local-path-migration-down-script-path migration)))))

--- a/t/rdbms-postgresql-driver.lisp
+++ b/t/rdbms-postgresql-driver.lisp
@@ -1,0 +1,98 @@
+;; Copyright (c) 2020-2022 Marin Atanasov Nikolov <dnaeon@gmail.com>
+;; All rights reserved.
+;;
+;; Redistribution and use in source and binary forms, with or without
+;; modification, are permitted provided that the following conditions
+;; are met:
+;;
+;;  1. Redistributions of source code must retain the above copyright
+;;     notice, this list of conditions and the following disclaimer
+;;     in this position and unchanged.
+;;  2. Redistributions in binary form must reproduce the above copyright
+;;     notice, this list of conditions and the following disclaimer in the
+;;     documentation and/or other materials provided with the distribution.
+;;
+;; THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+;; IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+;; OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+;; IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+;; INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+;; NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+;; DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+;; THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+;; (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+;; THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+(in-package :cl-migratum.test)
+
+(deftest rdbms-postgresql-driver
+  (testing "driver-name"
+    (ok (string= "RDBMS-PG" (driver-name *rdbms-postgresql-driver*)) "driver name matches"))
+
+  (testing "driver-initialized"
+    (ok (eq nil (driver-initialized *rdbms-postgresql-driver*)) "driver is not yet initialized"))
+
+  (testing "driver-init"
+    (ok (eq t (driver-init *rdbms-postgresql-driver*)) "initialize driver")
+    (ok (eq t (driver-initialized *rdbms-postgresql-driver*)) "driver is initialized"))
+
+  (testing "driver-list-applied"
+    (ng (driver-list-applied *rdbms-postgresql-driver*) "no migrations have been applied yet"))
+
+  (testing "contains-applied-migrations-p"
+    (ok (eq nil (contains-applied-migrations-p *rdbms-postgresql-driver*)) "does not contain applied migrations"))
+
+  (testing "list-pending"
+    (let ((pending (list-pending *rdbms-postgresql-driver*)))
+      (ok (= 4 (length pending)) "number of pending migrations matches")
+      (ok (equal (list 20200421173657 20200421173908 20200421180337 20200605144633)
+                 (mapcar #'migration-id pending))
+          "identifiers of pending migrations matches")))
+
+  (testing "apply-pending"
+    (apply-pending *rdbms-postgresql-driver*)
+    (let ((applied (driver-list-applied *rdbms-postgresql-driver*)))
+      (ok (= 4 (length applied)) "number of applied migrations matches")
+      (ok (equal (list 20200605144633 20200421180337 20200421173908 20200421173657)
+                 (mapcar #'migration-id applied))
+          "identifiers of applied migrations matches")))
+
+  (testing "pagination"
+    (ok (= 1 (length (driver-list-applied *rdbms-postgresql-driver* :offset 0 :limit 1)))
+        "page with :offset 0 :limit 1")
+    (ok (= 1 (length (driver-list-applied *rdbms-postgresql-driver* :offset 1 :limit 1)))
+        "page with :offset 1 :limit 1")
+    (ok (= 2 (length (driver-list-applied *rdbms-postgresql-driver* :offset 1 :limit 2)))
+        "page with :offset 1 :limit 2")
+    (ng (driver-list-applied *rdbms-postgresql-driver* :offset 100 :limit 100)
+        "page with :offset 100 :limit 100"))
+
+  (testing "latest-migration"
+    (ok (= 20200605144633 (migration-id (latest-migration *rdbms-postgresql-driver*)))
+        "latest migration id matches"))
+
+  (testing "revert-last"
+    (revert-last *rdbms-postgresql-driver* :count 4)
+    (ng (contains-applied-migrations-p *rdbms-postgresql-driver*)
+        "no migrations present after revert")
+    (ng (driver-list-applied *rdbms-postgresql-driver*)
+        "no migrations applied after revert"))
+
+  (testing "apply-next"
+    (ng (contains-applied-migrations-p *rdbms-postgresql-driver*)
+        "no migrations present yet")
+    (apply-next *rdbms-postgresql-driver*)
+    (ok (= 20200421173657 (migration-id (latest-migration *rdbms-postgresql-driver*)))
+        "id matches next applied migration")
+    (apply-next *rdbms-postgresql-driver*)
+    (ok (= 20200421173908 (migration-id (latest-migration *rdbms-postgresql-driver*)))
+        "id matches next applied migration")
+    (apply-next *rdbms-postgresql-driver*)
+    (ok (= 20200421180337 (migration-id (latest-migration *rdbms-postgresql-driver*)))
+        "id matches next applied migration")
+    (apply-next *rdbms-postgresql-driver*)
+    (ok (= 20200605144633 (migration-id (latest-migration *rdbms-postgresql-driver*)))
+        "id matches next applied migration")
+    (apply-next *rdbms-postgresql-driver*) ;; No more pending migrations at this point
+    (ok (= 20200605144633 (migration-id (latest-migration *rdbms-postgresql-driver*)))
+        "id of last migration is the same"))) ;; ID did not change, since previous migration

--- a/t/rdbms-postgresql-driver.lisp
+++ b/t/rdbms-postgresql-driver.lisp
@@ -1,4 +1,4 @@
-;; Copyright (c) 2020-2022 Marin Atanasov Nikolov <dnaeon@gmail.com>
+;; Copyright (c) 2020-2022 Marin Atanasov Nikolov <dnaeon@gmail.com>, Kambiz Darabi <darabi@m-creations.net>
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/t/test-suite.lisp
+++ b/t/test-suite.lisp
@@ -59,9 +59,8 @@
    :make-local-path-provider
    :local-path-migration-up-script-path
    :local-path-migration-down-script-path)
-  (:import-from
-   :migratum.driver.dbi
-   :make-driver))
+  (:import-from :migratum.driver.dbi)
+  (:import-from :migratum.driver.rdbms-postgresql))
 (in-package :cl-migratum.test)
 
 (defparameter *migrations-path*
@@ -76,9 +75,13 @@
   nil
   "CL-DBI connection used during tests")
 
-(defparameter *driver*
+(defparameter *dbi-driver*
   nil
   "DBI driver used during tests")
+
+(defparameter *rdbms-postgresql-driver*
+  nil
+  "Driver from library hu.dwim.rdbms for PostgreSQL")
 
 (defparameter *provider*
   nil
@@ -102,126 +105,6 @@
 
 (teardown
   (provider-shutdown *provider*)
-  (driver-shutdown *driver*)
+  (driver-shutdown *dbi-driver*)
   (when *tmpdir*
     (uiop:delete-directory-tree *tmpdir* :validate t)))
-
-(deftest local-path-provider
-  (testing "provider-name"
-    (ok (string= "local-path" (provider-name *provider*))
-        "provider name matches"))
-
-  (testing "provider-init"
-    (ok (provider-init *provider*)
-        "initialize provider"))
-
-  (testing "provider-initialized"
-    (ok (provider-initialized *provider*)
-        "provider is initialized"))
-
-  (testing "provider-list-migrations"
-    (let* ((discovered (provider-list-migrations *provider*))
-           (migrations (sort discovered #'< :key #'migration-id)))
-      (ok (= 4 (length migrations)) "number of migrations matches")
-      (ok (equal (list 20200421173657 20200421173908 20200421180337 20200605144633)
-                 (mapcar #'migration-id migrations))
-          "identifiers of migrations matches")
-      (ok (equal (list "create_table_foo" "create_table_bar" "create_table_qux" "multiple_statements")
-                 (mapcar #'migration-description migrations))
-          "description of migrations matches")))
-
-  (testing "provider-find-migration-by-id"
-    (ok (provider-find-migration-by-id *provider* 20200421173657)
-        "find existing migration by id")
-    (ng (provider-find-migration-by-id *provider* 'no-such-id)
-        "find non-existing migration"))
-
-  (testing "provider-create-migration"
-    (let* ((migration (provider-create-migration *provider*
-                                                 :description "my-new-migration"
-                                                 :up "CREATE TABLE cl_migratum_test (id INTEGER PRIMARY KEY);"
-                                                 :down "DROP TABLE cl_migratum_test;")))
-      (ok (numberp (migration-id migration))
-          "migration id is a number")
-      (ok (string= "my_new_migration" (migration-description migration))
-          "migration description matches")
-      (ok (string= "CREATE TABLE cl_migratum_test (id INTEGER PRIMARY KEY);"
-                   (migration-load-up-script migration))
-          "upgrade script matches")
-      (ok (string= "DROP TABLE cl_migratum_test;"
-                   (migration-load-down-script migration))
-          "downgrade script matches")
-      (uiop:delete-file-if-exists (local-path-migration-up-script-path migration))
-      (uiop:delete-file-if-exists (local-path-migration-down-script-path migration)))))
-
-(deftest dbi-driver
-  (testing "driver-name"
-    (ok (string= "DBI" (driver-name *driver*)) "driver name matches"))
-
-  (testing "driver-initialized"
-    (ok (eq nil (driver-initialized *driver*)) "driver is not yet initialized"))
-
-  (testing "driver-init"
-    (ok (eq t (driver-init *driver*)) "initialize driver")
-    (ok (eq t (driver-initialized *driver*)) "driver is initialized"))
-
-  (testing "driver-list-applied"
-    (ng (driver-list-applied *driver*) "no migrations have been applied yet"))
-
-  (testing "contains-applied-migrations-p"
-    (ok (eq nil (contains-applied-migrations-p *driver*)) "does not contain applied migrations"))
-
-  (testing "list-pending"
-    (let ((pending (list-pending *driver*)))
-      (ok (= 4 (length pending)) "number of pending migrations matches")
-      (ok (equal (list 20200421173657 20200421173908 20200421180337 20200605144633)
-                 (mapcar #'migration-id pending))
-          "identifiers of pending migrations matches")))
-
-  (testing "apply-pending"
-    (apply-pending *driver*)
-    (let ((applied (driver-list-applied *driver*)))
-      (ok (= 4 (length applied)) "number of applied migrations matches")
-      (ok (equal (list 20200605144633 20200421180337 20200421173908 20200421173657)
-                 (mapcar #'migration-id applied))
-          "identifiers of applied migrations matches")))
-
-  (testing "pagination"
-    (ok (= 1 (length (driver-list-applied *driver* :offset 0 :limit 1)))
-        "page with :offset 0 :limit 1")
-    (ok (= 1 (length (driver-list-applied *driver* :offset 1 :limit 1)))
-        "page with :offset 1 :limit 1")
-    (ok (= 2 (length (driver-list-applied *driver* :offset 1 :limit 2)))
-        "page with :offset 1 :limit 2")
-    (ng (driver-list-applied *driver* :offset 100 :limit 100)
-        "page with :offset 100 :limit 100"))
-
-  (testing "latest-migration"
-    (ok (= 20200605144633 (migration-id (latest-migration *driver*)))
-        "latest migration id matches"))
-
-  (testing "revert-last"
-    (revert-last *driver* :count 4)
-    (ng (contains-applied-migrations-p *driver*)
-        "no migrations present after revert")
-    (ng (driver-list-applied *driver*)
-        "no migrations applied after revert"))
-
-  (testing "apply-next"
-    (ng (contains-applied-migrations-p *driver*)
-        "no migrations present yet")
-    (apply-next *driver*)
-    (ok (= 20200421173657 (migration-id (latest-migration *driver*)))
-        "id matches next applied migration")
-    (apply-next *driver*)
-    (ok (= 20200421173908 (migration-id (latest-migration *driver*)))
-        "id matches next applied migration")
-    (apply-next *driver*)
-    (ok (= 20200421180337 (migration-id (latest-migration *driver*)))
-        "id matches next applied migration")
-    (apply-next *driver*)
-    (ok (= 20200605144633 (migration-id (latest-migration *driver*)))
-        "id matches next applied migration")
-    (apply-next *driver*) ;; No more pending migrations at this point
-    (ok (= 20200605144633 (migration-id (latest-migration *driver*)))
-        "id of last migration is the same"))) ;; ID did not change, since previous migration

--- a/t/test-suite.lisp
+++ b/t/test-suite.lisp
@@ -91,8 +91,14 @@
                         :database-name (merge-pathnames (make-pathname :name "cl-migratum" :type "db")
                                                         *tmpdir*)))
   (setf *provider* (make-local-path-provider (list *migrations-path*)))
-  (setf *driver*
-        (make-driver *provider* *sqlite-conn*)))
+  (setf *dbi-driver*
+        (migratum.driver.dbi:make-driver *provider* *sqlite-conn*))
+  (setf *rdbms-postgresql-driver*
+        (migratum.driver.rdbms-postgresql:make-driver *provider*
+                                                      `(:host ,(or (uiop:getenv "PGHOST") "localhost")
+                                                        :database ,(or (uiop:getenv "PGDATABASE") "migratum")
+                                                        :user-name ,(or (uiop:getenv "PGUSER") "migratum")
+                                                        :password ,(or (uiop:getenv "PGPASSWORD") "FvbRd5qdeWHNum9p")))))
 
 (teardown
   (provider-shutdown *provider*)


### PR DESCRIPTION
The library hu.dwim.rdbms supports several database backends
(PostgreSQL, SQLite, and Oracle) through a uniform interface. The
PostgreSQL backend uses Postmodern's [1] cl-postgres [2] library.
    
Tests from test-suite.lisp are split in separate files.
    
[1] https://marijnhaverbeke.nl/postmodern/
[2] https://marijnhaverbeke.nl/postmodern/cl-postgres.html
