### PR TITLE
Add support for functional migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,16 @@ important that you get familiar with them first.
 
 A `migration` represents a resource that provides information about a
 schema change, e.g. it provides the unique id of the change, the
-required scripts that can be used to upgrade and/or downgrade the
+required scripts or functions that can be used to upgrade and/or downgrade the
 database.
+
+Two different types of `migration` exist:
+- SQL script migrations
+- functional migrations
+
+SQL script migrations consist of one or multiple SQL statements, and
+functional migrations are defined by the name of a function, which has
+to exist in a CL package.
 
 Migration resources are discovered via `providers` and are being
 used by `drivers` during the process of upgrade/downgrade of the
@@ -113,8 +121,13 @@ The `LOCAL-PATH-PROVIDER` discovers migration files which match the following pa
 
 | Pattern                       | Description      |
 |-------------------------------|------------------|
-| `<id>-<description>.up.sql`   | Upgrade script   |
-| `<id>-<description>.down.sql` | Downgrade script |
+| `<id>-<description>.up.sql`   | Upgrade SQL script, consisting of one or multiple SQL statements |
+| `<id>-<description>.down.sql` | Downgrade SQL script, consisting of one or multiple SQL statements |
+| `<id>-<description>.up.sexp`   | Upgrade function specification, a property list with key `:function` followed by a function name  |
+| `<id>-<description>.down.sexp` | Downgrade function specification, a property list with key `:function` followed by a function name  |
+
+In case of functional migration files, a size limit of 1000 characters
+exists.
 
 A provider can optionally be initialized, which can be done using the
 `MIGRATUM:PROVIDER-INIT` generic function. Not all providers would

--- a/src/core.lisp
+++ b/src/core.lisp
@@ -36,13 +36,13 @@
    :migration-id
    :migration-description
    :migration-applied
-   :migration-load-up-script
-   :migration-load-down-script
+   :migration-load
    :base-provider
    :provider-init
    :provider-shutdown
    :provider-initialized
    :provider-name
+   :provider-package
    :provider-list-migrations
    :provider-create-migration
    :provider-find-migration-by-id
@@ -87,11 +87,11 @@
     :documentation "Timestamp when the migration was applied"))
   (:documentation "Base class for migration resources"))
 
-(defgeneric migration-load-up-script (migration &key)
-  (:documentation "Returns the contents of the upgrade migration script"))
-
-(defgeneric migration-load-down-script (migration &key)
-  (:documentation "Returns the contents of the downgrade migration script"))
+(defgeneric migration-load (migration direction package &key)
+  (:documentation
+   "Returns either the contents of the migration script as a string or a
+function which will be called. Argument direction must be :up or :down, package
+is the package where functional migrations are found."))
 
 (defclass base-provider ()
   ((name
@@ -104,7 +104,12 @@
     :initarg :initialized
     :initform nil
     :accessor provider-initialized
-    :documentation "Returns T if provider is initialized, NIL otherwise"))
+    :documentation "Returns T if provider is initialized, NIL otherwise")
+   (package
+    :initarg :package
+    :initform (find-package :keyword)
+    :accessor provider-package
+    :documentation "The package which contains migration functions"))
   (:documentation "Base class for migration providers"))
 
 (defgeneric provider-init (provider &key)

--- a/t/local-path-provider.lisp
+++ b/t/local-path-provider.lisp
@@ -41,11 +41,11 @@
   (testing "provider-list-migrations"
     (let* ((discovered (provider-list-migrations *provider*))
            (migrations (sort discovered #'< :key #'migration-id)))
-      (ok (= 4 (length migrations)) "number of migrations matches")
-      (ok (equal (list 20200421173657 20200421173908 20200421180337 20200605144633)
+      (ok (= 5 (length migrations)) "number of migrations matches")
+      (ok (equal (list 20200421173657 20200421173908 20200421180000 20200421180337 20200605144633)
                  (mapcar #'migration-id migrations))
           "identifiers of migrations matches")
-      (ok (equal (list "create_table_foo" "create_table_bar" "create_table_qux" "multiple_statements")
+      (ok (equal (list "create_table_foo" "create_table_bar" "create_table_baz" "create_table_qux" "multiple_statements")
                  (mapcar #'migration-description migrations))
           "description of migrations matches")))
 
@@ -55,7 +55,7 @@
     (ng (provider-find-migration-by-id *provider* 'no-such-id)
         "find non-existing migration"))
 
-  (testing "provider-create-migration"
+  (testing "provider-create-sql-migration"
     (let* ((migration (provider-create-migration *provider*
                                                  :description "my-new-migration"
                                                  :up "CREATE TABLE cl_migratum_test (id INTEGER PRIMARY KEY);"
@@ -65,10 +65,63 @@
       (ok (string= "my_new_migration" (migration-description migration))
           "migration description matches")
       (ok (string= "CREATE TABLE cl_migratum_test (id INTEGER PRIMARY KEY);"
-                   (migration-load-up-script migration))
+                   (migration-load migration :up :cl-migratum.test))
           "upgrade script matches")
       (ok (string= "DROP TABLE cl_migratum_test;"
-                   (migration-load-down-script migration))
+                   (migration-load migration :down :cl-migratum.test))
           "downgrade script matches")
       (uiop:delete-file-if-exists (local-path-migration-up-script-path migration))
-      (uiop:delete-file-if-exists (local-path-migration-down-script-path migration)))))
+      (uiop:delete-file-if-exists (local-path-migration-down-script-path migration))))
+
+  (testing "provider-create-functional-migration-happy-path"
+    (let* ((migration (provider-create-migration *provider*
+                                                 :description "my-functional-migration"
+                                                 :up "(:function create-table-corge)"
+                                                 :down "(:function drop-table-corge)"
+                                                 :type :sexp)))
+      (ok (numberp (migration-id migration))
+          "migration id is a number")
+      (ok (string= "my_functional_migration" (migration-description migration))
+          "migration description matches")
+      (ok (eq :sexp (local-path-migration-up-script-type migration))
+          "type slot of functional migration upgrade script is :sexp")
+      (ok (eq :sexp (local-path-migration-down-script-type migration))
+          "type slot of functional migration downgrade script is :sexp")
+      (ok (eq #'create-table-corge (migration-load migration :up :cl-migratum.test))
+          "upgrade script matches")
+      (ok (eq #'drop-table-corge (migration-load migration :down :cl-migratum.test))
+          "downgrade script matches")
+      (uiop:delete-file-if-exists (local-path-migration-up-script-path migration))
+      (uiop:delete-file-if-exists (local-path-migration-down-script-path migration))))
+
+  (testing "provider-create-functional-migration-errors"
+    (ok (signals (provider-create-migration *provider*
+                                            :description "my-functional-migration"
+                                            :up "(:function create-table-corge)"
+                                            :down "(:function drop-table-corge)"
+                                            :type :something-else))
+        "a migration type other that :sql or :sexp signals an error")
+    (ok (signals (provider-create-migration *provider*
+                                            :description "my-functional-migration"
+                                            :up "(:function cl:print)"
+                                            :down "(:function drop-table-corge)"
+                                            :type :sexp))
+        "upgrade function in the wrong package signals an error")
+    (ok (signals (provider-create-migration *provider*
+                                            :description "my-functional-migration"
+                                            :up "(:function create-table-corge)"
+                                            :down "(:function cl:print)"
+                                            :type :sexp))
+        "downgrade function in the wrong package signals an error")
+    (ok (signals (provider-create-migration *provider*
+                                            :description "my-functional-migration"
+                                            :up (format nil "~{:~a~^ ~}" (loop for i from 1 upto 1000 collect i))
+                                            :down "(:function drop-table-corge)"
+                                            :type :sexp))
+        "long upgrade function s-expression signals an error")
+    (ok (signals (provider-create-migration *provider*
+                                            :description "my-functional-migration"
+                                            :up "(:function create-table-corge)"
+                                            :down (format nil "~{:~a~^ ~}" (loop for i from 1 upto 1000 collect i))
+                                            :type :sexp))
+        "long downgrade function s-expression signals an error")))

--- a/t/migrations/20200421180000-create_table_baz.down.sexp
+++ b/t/migrations/20200421180000-create_table_baz.down.sexp
@@ -1,0 +1,1 @@
+(:function drop-table-baz)

--- a/t/migrations/20200421180000-create_table_baz.up.sexp
+++ b/t/migrations/20200421180000-create_table_baz.up.sexp
@@ -1,0 +1,1 @@
+(:function create-table-baz)


### PR DESCRIPTION
Functional migrations are not defined by an SQL script but performed
programmatically by providing a function with one argument. The
function receives the connection or database object of the underlying
SQL driver library which is used by the application. The function is
executed within the context of a database transaction.

To reduce the risk which is associated with allowing function calls
via file input, the package which contains the function has to be
defined when initialising a provider (see slot `package`, default is
the `keyword` package which usually doesn't contain functions).

For an example of functional migrations, refer to t/test-suite.lisp
but keep in mind that the test is overly complex as it has to test
multiple drivers.

This change fixes #6.