### PR TITLE
Rewrite cl-migratum.utils:make-migration-id

### DIFF
--- a/src/util.lisp
+++ b/src/util.lisp
@@ -38,9 +38,9 @@
       sequence
       (subseq sequence 0 n)))
 
-(defun make-migration-id ()
+(defun make-migration-id (&optional (timezone local-time:+utc-zone+))
   "Creates a new migration id from current timestamp"
-  (local-time:with-decoded-timestamp (:year year :month month :day day :hour hour :minute minute :sec sec)
+  (local-time:with-decoded-timestamp (:year year :month month :day day :hour hour :minute minute :sec sec :timezone timezone)
                                      (local-time:now)
     ;; use only the first value returned from parse-integer
     (values (parse-integer (format nil "~d~2,'0d~2,'0d~2,'0d~2,'0d~2,'0d" year month day hour minute sec)))))

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -40,12 +40,7 @@
 
 (defun make-migration-id ()
   "Creates a new migration id"
-  (let* ((now (local-time:now))
-         (year (format nil "~d" (local-time:timestamp-year now)))
-         (month (format nil "~2,'0d" (local-time:timestamp-month now)))
-         (day (format nil "~2,'0d" (local-time:timestamp-day now)))
-         (hour (format nil "~2,'0d" (local-time:timestamp-hour now)))
-         (minute (format nil "~2,'0d" (local-time:timestamp-minute now)))
-         (sec (format nil "~2,'0d" (local-time:timestamp-second now)))
-         (timestamp-id (parse-integer (format nil "~a~a~a~a~a~a" year month day hour minute sec))))
-    timestamp-id))
+  (local-time:with-decoded-timestamp (:year year :month month :day day :hour hour :minute minute :sec sec)
+                                     (local-time:now)
+    (let ((timestamp-id (parse-integer (format nil "~d~2,'0d~2,'0d~2,'0d~2,'0d~2,'0d" year month day hour minute sec))))
+      timestamp-id)))

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -39,8 +39,8 @@
       (subseq sequence 0 n)))
 
 (defun make-migration-id ()
-  "Creates a new migration id"
+  "Creates a new migration id from current timestamp"
   (local-time:with-decoded-timestamp (:year year :month month :day day :hour hour :minute minute :sec sec)
                                      (local-time:now)
-    (let ((timestamp-id (parse-integer (format nil "~d~2,'0d~2,'0d~2,'0d~2,'0d~2,'0d" year month day hour minute sec))))
-      timestamp-id)))
+    ;; use only the first value returned from parse-integer
+    (values (parse-integer (format nil "~d~2,'0d~2,'0d~2,'0d~2,'0d~2,'0d" year month day hour minute sec)))))


### PR DESCRIPTION
1. Used local-time:with-decoded-timestamp to bind variables. (Maybe I would do meta programming to reduce symbol name redundancy in the future)
2. Edited docstring and tweaked code conciseness.
3. (The point of this PR) Used +utc-zone+ as default zone to make timestamp for migration-id. It should be better for worldwide coworking.
