### PR TITLE
provider-touch-migration for sql

### DIFF
--- a/src/core.lisp
+++ b/src/core.lisp
@@ -45,6 +45,7 @@
    :provider-name
    :provider-list-migrations
    :provider-create-migration
+   :provider-touch-migration
    :find-migration-by-id
    :base-driver
    :driver-name
@@ -137,6 +138,9 @@
 
 (defgeneric provider-create-migration (direction kind provider id description content &key)
   (:documentation "Creates a new migration resource using the given provider"))
+
+(defgeneric provider-touch-migration (kind provider description &key id-generating-function)
+  (:documentation "Creates an empty up-and-down pair of migration resources using the given provider"))
 
 (defgeneric find-migration-by-id (provider id)
   (:documentation "Returns the migration with the given id from the provider"))

--- a/src/provider/local-path.lisp
+++ b/src/provider/local-path.lisp
@@ -39,6 +39,7 @@
    :migration-kind
    :provider-list-migrations
    :provider-create-migration
+   :provider-touch-migration
    :make-migration-id)
   (:export
    :migration-file-p
@@ -292,6 +293,18 @@ GROUP-MIGRATION-FILES-BY id function."
                    :applied nil
                    :up-script-path nil
                    :down-script-path file-path)))
+
+(defmethod provider-touch-migration ((kind (eql :sql))
+                                     (provider local-path-provider)
+                                     (description string)
+                                     &key (id-generating-function #'make-migration-id))
+  (let ((args (list :sql
+                    provider
+                    (funcall id-generating-function)
+                    description
+                    "")))
+    (values (apply #'provider-create-migration (cons :up args))
+            (apply #'provider-create-migration (cons :down args)))))
 
 (defun %write-lisp-migration-file (id description direction path content)
   (log:debug "[LISP] Creating new migration in ~A" path)


### PR DESCRIPTION
provider-touch-migration: A handy wrapper of provider-create-migration to create (touch) an empty up-and-down pair of migration resources.

Only implemented sql kind for now.

Lisp kind (not implemented yet) requires some redesign which could result in backward incompatibility. That is, this PR (sql kind only) is still backward compatible.