### PR TITLE
Provider touch migration for sql

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,7 +535,10 @@ new migration sequence. The arguments it expects are the `direction`
 (e.g. `:up` or `:down`), the migration `kind` (e.g. `:sql`, `:lisp`,
 etc.), an instance of a `provider`, `id`, `description` and `content`.
 
-Knowing `migratum:provider-create-migration` by the documentation below, you can also use the wrapper `migratum.provider.local-path:touch-migration` to create a pair of up-and-down empty migrations with a `LOCAL-PATH` provider.
+Knowing `migratum:provider-create-migration` by the documentation 
+below, you can also use the wrapper 
+`migratum.provider.local-path:touch-migration` to create a pair of 
+up-and-down empty migrations with a `LOCAL-PATH` provider.
 
 #### SQL migrations
 

--- a/README.md
+++ b/README.md
@@ -535,7 +535,7 @@ new migration sequence. The arguments it expects are the `direction`
 (e.g. `:up` or `:down`), the migration `kind` (e.g. `:sql`, `:lisp`,
 etc.), an instance of a `provider`, `id`, `description` and `content`.
 
-Knowing `migratum:provider-create-migration` with the documentation below, you can also use the wrapper `migratum.provider.local-path:touch-migration` to create a pair of up-and-down empty migrations with a `LOCAL-PATH` provider.
+Knowing `migratum:provider-create-migration` by the documentation below, you can also use the wrapper `migratum.provider.local-path:touch-migration` to create a pair of up-and-down empty migrations with a `LOCAL-PATH` provider.
 
 #### SQL migrations
 

--- a/README.md
+++ b/README.md
@@ -535,6 +535,8 @@ new migration sequence. The arguments it expects are the `direction`
 (e.g. `:up` or `:down`), the migration `kind` (e.g. `:sql`, `:lisp`,
 etc.), an instance of a `provider`, `id`, `description` and `content`.
 
+Knowing `migratum:provider-create-migration` with the documentation below, you can also use the wrapper `migratum.provider.local-path:touch-migration` to create a pair of up-and-down empty migrations with a `LOCAL-PATH` provider.
+
 #### SQL migrations
 
 Here's an example of using the `LOCAL-PATH` provider for creating a

--- a/src/core.lisp
+++ b/src/core.lisp
@@ -45,6 +45,7 @@
    :provider-name
    :provider-list-migrations
    :provider-create-migration
+   :provider-touch-migration
    :find-migration-by-id
    :base-driver
    :driver-name
@@ -137,6 +138,9 @@
 
 (defgeneric provider-create-migration (direction kind provider id description content &key)
   (:documentation "Creates a new migration resource using the given provider"))
+
+(defgeneric provider-touch-migration (kind provider description &key id-generating-function)
+  (:documentation "Creates an empty up-and-down pair of migration resources using the given provider"))
 
 (defgeneric find-migration-by-id (provider id)
   (:documentation "Returns the migration with the given id from the provider"))

--- a/src/core.lisp
+++ b/src/core.lisp
@@ -45,7 +45,6 @@
    :provider-name
    :provider-list-migrations
    :provider-create-migration
-   :provider-touch-migration
    :find-migration-by-id
    :base-driver
    :driver-name
@@ -138,9 +137,6 @@
 
 (defgeneric provider-create-migration (direction kind provider id description content &key)
   (:documentation "Creates a new migration resource using the given provider"))
-
-(defgeneric provider-touch-migration (kind provider description &key id-generating-function)
-  (:documentation "Creates an empty up-and-down pair of migration resources using the given provider"))
 
 (defgeneric find-migration-by-id (provider id)
   (:documentation "Returns the migration with the given id from the provider"))

--- a/src/provider/local-path.lisp
+++ b/src/provider/local-path.lisp
@@ -317,8 +317,7 @@ GROUP-MIGRATION-FILES-BY id function."
                     local-path-provider
                     (funcall id-generating-function)
                     description
-                    (format nil "~%;; TODO: replace :my-system, :my-package, and my-hander-function as you need, so cl-migration can find your migration handler function. ~%~%"
-                            '(:system :my-system :package :my-package :handler :my-handler-function)))))
+                    '(:system :my-system :package :my-package :handler :my-handler-function))))
     (values (apply #'provider-create-migration (cons :up args))
             (apply #'provider-create-migration (cons :down args)))))
 

--- a/src/provider/local-path.lisp
+++ b/src/provider/local-path.lisp
@@ -295,7 +295,13 @@ GROUP-MIGRATION-FILES-BY id function."
                    :down-script-path file-path)))
 
 (defgeneric touch-migration (kind local-path-provider description &key id-generating-function)
-  (:documentation "Creates an empty up-and-down pair of migration resources using the given local-path-provider. If KIND is :lisp, for cl-migratum to invoke your lisp migration handler function, please replace :my-system, :my-package, :my-handler-function in the newly created pair of files as your need."))
+  (:documentation "Creates an empty up-and-down pair of migration
+  resources using the given local-path-provider.
+
+  If KIND is :lisp, for cl-migratum to invoke your lisp migration
+  handler function, please replace :my-system, :my-package,
+  :my-handler-function in the newly created pair of files
+  as your need."))
 
 (defmethod touch-migration ((kind (eql :sql))
                             (local-path-provider local-path-provider)

--- a/src/provider/local-path.lisp
+++ b/src/provider/local-path.lisp
@@ -39,7 +39,6 @@
    :migration-kind
    :provider-list-migrations
    :provider-create-migration
-   :provider-touch-migration
    :make-migration-id)
   (:export
    :migration-file-p
@@ -55,7 +54,8 @@
    :provider-paths
    :provider-scan-pattern
    :provider-file-mappings
-   :make-provider))
+   :make-provider
+   :touch-migration))
 (in-package :cl-migratum.provider.local-path)
 
 (defclass local-path-migration (base-migration)
@@ -294,12 +294,15 @@ GROUP-MIGRATION-FILES-BY id function."
                    :up-script-path nil
                    :down-script-path file-path)))
 
-(defmethod provider-touch-migration ((kind (eql :sql))
-                                     (provider local-path-provider)
+(defgeneric touch-migration (kind local-path-provider description &key id-generating-function)
+  (:documentation "Creates an empty up-and-down pair of migration resources using the given local-path-provider"))
+
+(defmethod touch-migration ((kind (eql :sql))
+                                     (local-path-provider local-path-provider)
                                      (description string)
                                      &key (id-generating-function #'make-migration-id))
   (let ((args (list :sql
-                    provider
+                    local-path-provider
                     (funcall id-generating-function)
                     description
                     "")))

--- a/src/provider/local-path.lisp
+++ b/src/provider/local-path.lisp
@@ -309,6 +309,19 @@ GROUP-MIGRATION-FILES-BY id function."
     (values (apply #'provider-create-migration (cons :up args))
             (apply #'provider-create-migration (cons :down args)))))
 
+(defmethod touch-migration ((kind (eql :lisp))
+                            (local-path-provider local-path-provider)
+                            (description string)
+                            &key (id-generating-function #'make-migration-id))
+  (let ((args (list :lisp
+                    local-path-provider
+                    (funcall id-generating-function)
+                    description
+                    (format nil "~%;; TODO: replace :my-system, :my-package, and my-hander-function as you need, so cl-migration can find your migration handler function. ~%~%"
+                            '(:system :my-system :package :my-package :handler :my-handler-function)))))
+    (values (apply #'provider-create-migration (cons :up args))
+            (apply #'provider-create-migration (cons :down args)))))
+
 (defun %write-lisp-migration-file (id description direction path content)
   (log:debug "[LISP] Creating new migration in ~A" path)
   (let ((system-name (getf content :system))

--- a/src/provider/local-path.lisp
+++ b/src/provider/local-path.lisp
@@ -295,7 +295,7 @@ GROUP-MIGRATION-FILES-BY id function."
                    :down-script-path file-path)))
 
 (defgeneric touch-migration (kind local-path-provider description &key id-generating-function)
-  (:documentation "Creates an empty up-and-down pair of migration resources using the given local-path-provider"))
+  (:documentation "Creates an empty up-and-down pair of migration resources using the given local-path-provider. If KIND is :lisp, for migratum to find your lisp migration function, please replace :my-system, :my-package, :my-handler-function as your need."))
 
 (defmethod touch-migration ((kind (eql :sql))
                             (local-path-provider local-path-provider)

--- a/src/provider/local-path.lisp
+++ b/src/provider/local-path.lisp
@@ -39,6 +39,7 @@
    :migration-kind
    :provider-list-migrations
    :provider-create-migration
+   :provider-touch-migration
    :make-migration-id)
   (:export
    :migration-file-p
@@ -292,6 +293,18 @@ GROUP-MIGRATION-FILES-BY id function."
                    :applied nil
                    :up-script-path nil
                    :down-script-path file-path)))
+
+(defmethod provider-touch-migration ((kind (eql :sql))
+                                     (provider local-path-provider)
+                                     (description string)
+                                     &key (id-generating-function #'make-migration-id))
+  (let ((args (list :sql
+                    provider
+                    (funcall id-generating-function)
+                    description
+                    "")))
+    (values (apply #'provider-create-migration (cons :up args))
+            (apply #'provider-create-migration (cons :down args)))))
 
 (defun %write-lisp-migration-file (id description direction path content)
   (log:debug "[LISP] Creating new migration in ~A" path)

--- a/src/provider/local-path.lisp
+++ b/src/provider/local-path.lisp
@@ -298,9 +298,9 @@ GROUP-MIGRATION-FILES-BY id function."
   (:documentation "Creates an empty up-and-down pair of migration resources using the given local-path-provider"))
 
 (defmethod touch-migration ((kind (eql :sql))
-                                     (local-path-provider local-path-provider)
-                                     (description string)
-                                     &key (id-generating-function #'make-migration-id))
+                            (local-path-provider local-path-provider)
+                            (description string)
+                            &key (id-generating-function #'make-migration-id))
   (let ((args (list :sql
                     local-path-provider
                     (funcall id-generating-function)

--- a/src/provider/local-path.lisp
+++ b/src/provider/local-path.lisp
@@ -295,7 +295,7 @@ GROUP-MIGRATION-FILES-BY id function."
                    :down-script-path file-path)))
 
 (defgeneric touch-migration (kind local-path-provider description &key id-generating-function)
-  (:documentation "Creates an empty up-and-down pair of migration resources using the given local-path-provider. If KIND is :lisp, for migratum to find your lisp migration function, please replace :my-system, :my-package, :my-handler-function as your need."))
+  (:documentation "Creates an empty up-and-down pair of migration resources using the given local-path-provider. If KIND is :lisp, for cl-migratum to invoke your lisp migration handler function, please replace :my-system, :my-package, :my-handler-function in the newly created pair of files as your need."))
 
 (defmethod touch-migration ((kind (eql :sql))
                             (local-path-provider local-path-provider)


### PR DESCRIPTION
Here I try to resume #15 . However, this time, I don't modify the `core`.

Let me quote a sentence from #common-lisp channel on the [Lisp Discord server](https://discord.gg/hhk46CE) again.
> quasus — 04/30/2022
> ......my point is that the Lisp process is our OS and REPL is our shell. Why do you need the Unix shell at all? If your code is organized as an ASDF library, most likely you can quickload it. Then it's there, in your "world". If there's a function that does stuff you need, you can call it. If you need this to be automated, you can e. g. write a "script" to a lisp file and LOAD it when the lisp starts. Or you can save an image with a custom entry point.

Thus, in my opinion, at least in the case of `local-path-provider` and the system `cl-migratum.provider.local-path`, it should be handy to have a function for empty file creation, with naming borrowed from the shell `touch` command.

I haven't handled the case for `(kind (eql :lisp))`. I would probably find time to implement the `:lisp` `kind`, as well.

May I know your thoughts? Thank you.