### PR TITLE
Add postgres driver powered by Postmodern.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,7 +67,7 @@ jobs:
           --health-retries 5
         ports:
           # Maps tcp port 5433 on service container to the host for second postgres service.
-          - 5433:5433          
+          - 5433:5432          
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,6 +53,21 @@ jobs:
         ports:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
+      postgres2:
+        # Docker Hub PostgreSQL image
+        image: postgres
+        # Provide the password for postgres
+        env:
+          POSTGRES_USER: migratum
+          POSTGRES_PASSWORD: FvbRd5qdeWHNum9p
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # Maps tcp port 5433 on service container to the host for second postgres service.
+          - 5433:5433          
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/cl-migratum.driver.postmodern-postgresql.asd
+++ b/cl-migratum.driver.postmodern-postgresql.asd
@@ -1,0 +1,25 @@
+(defpackage :cl-migratum-driver-postmodern-postgresql-system
+  (:use :cl :asdf))
+(in-package :cl-migratum-driver-postmodern-postgresql-system)
+
+(defsystem "cl-migratum.driver.postmodern-postgresql"
+  :name "cl-migratum.driver.postmodern-postgresql"
+  :description "cl-migratum driver for driving migrations against SQL databases using Postmodern."
+  :version "0.1.3"
+  :author ("Marin Atanasov  <dnaeon@gmail.com>"
+           "Kambiz Darabi <darabi@m-creations.net>")
+  :maintainer "Marin Atanasov Nikolov <dnaeon@gmail.com>"
+  :license "BSD-2 Clause"
+  :homepage "https://github.com/dnaeon/cl-migratum"
+  :bug-tracker "https://github.com/dnaeon/cl-migratum"
+  :source-control "https://github.com/dnaeon/cl-migratum"
+  :long-name "cl-migratum.driver.postmodern-postgresql"
+  :depends-on (:cl-migratum
+               :cl-migratum.driver.mixins
+               :str
+               :hu.dwim.logger
+               :postmodern
+               :log4cl)
+  :components ((:module "driver"
+                :pathname #P"src/driver/"
+                :components ((:file "postmodern-postgresql")))))

--- a/cl-migratum.test.asd
+++ b/cl-migratum.test.asd
@@ -17,6 +17,7 @@
                :cl-migratum.provider.local-path
                :cl-migratum.driver.dbi
                :cl-migratum.driver.rdbms-postgresql
+               :cl-migratum.driver.postmodern-postgresql
                :dbd-sqlite3
                :tmpdir
                :rove)
@@ -39,5 +40,6 @@
                              (:file "20220327224455-migration")
                              (:file "local-path-provider")
                              (:file "dbi-driver")
-                             (:file "rdbms-postgresql-driver"))))
+                             (:file "rdbms-postgresql-driver")
+                             (:file "postmodern-postgresql-driver"))))
   :perform (test-op (op c) (uiop:symbol-call :rove :run-suite :cl-migratum.test)))

--- a/src/driver/postmodern-postgresql.lisp
+++ b/src/driver/postmodern-postgresql.lisp
@@ -1,0 +1,174 @@
+;; Copyright (c) 2020-2022 Marin Atanasov Nikolov <dnaeon@gmail.com>
+;; Copyright (c) 2022 Kambiz Darabi <darabi@m-creations.net>
+;; All rights reserved.
+;;
+;; Redistribution and use in source and binary forms, with or without
+;; modification, are permitted provided that the following conditions
+;; are met:
+;;
+;;  1. Redistributions of source code must retain the above copyright
+;;     notice, this list of conditions and the following disclaimer
+;;     in this position and unchanged.
+;;  2. Redistributions in binary form must reproduce the above copyright
+;;     notice, this list of conditions and the following disclaimer in the
+;;     documentation and/or other materials provided with the distribution.
+;;
+;; THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+;; IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+;; OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+;; IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+;; INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+;; NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+;; DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+;; THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+;; (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+;; THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+(in-package :cl-user)
+(defpackage :cl-migratum.driver.postmodern-postgresql
+  (:use :cl)
+  (:nicknames :migratum.driver.postmodern-postgresql)
+  (:import-from
+   :cl-migratum
+   :base-migration
+   :migration-id
+   :migration-kind
+   :migration-description
+   :migration-load
+   :base-driver
+   :driver-name
+   :driver-provider
+   :driver-init
+   :driver-shutdown
+   :driver-initialized
+   :driver-list-applied
+   :driver-apply-migration
+   :driver-register-migration)
+  (:export
+   :postmodern-postgresql-driver
+   :make-driver
+   :database-of
+   :connection-specification-of))
+(in-package :cl-migratum.driver.postmodern-postgresql)
+
+(defparameter *sql-statement-separator*
+  "--;;"
+  "Separator to use when splitting a migration into multiple statements")
+
+(defparameter *sql-init-schema*
+  "
+CREATE TABLE IF NOT EXISTS migration (
+    id BIGINT PRIMARY KEY,
+    kind CHARACTER VARYING(255) NOT NULL,
+    description TEXT NOT NULL,
+    applied TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);"
+  "Schema used by the SQL driver")
+
+(defclass postmodern-postgresql-driver (base-driver migratum.driver.mixins:lisp-driver-mixin)
+  ((connection-specification
+    :initarg :connection-specification
+    :reader connection-specification-of
+    :initform (error "Must specify database connection specification")
+    :documentation "Connection specification for Postmodern e.g. (:host \"localhost\" :port 5432 :database \"migratum\" :user-name \"migratum_user\" :password \"changeit\" :use-ssl :yes)
+    Note that :host defaults to \"localhost\", :port to 5432, and :use-ssl to :no"))
+  (:documentation "Driver for performing SQL migrations with Postmodern."))
+
+(defmethod initialize-instance :after ((-self- postmodern-postgresql-driver) &key)
+  (destructuring-bind (&key database user-name password (host "localhost")
+                         (port 5432) (use-ssl pomo:*default-use-ssl*)
+                         (application-name "")
+                         use-binary
+                       &allow-other-keys)
+      (connection-specification-of -self-)
+    (pomo:connect-toplevel database user-name password host
+                           :port port
+                           :use-ssl use-ssl
+                           :application-name application-name
+                           :use-binary use-binary)))
+
+(defmethod driver-init ((driver postmodern-postgresql-driver) &key)
+  (log:debug "[POSTMODERN-PGSQL] Initializing ~A driver" (driver-name driver))
+  (pomo:with-transaction ()
+      (pomo:query *sql-init-schema*))
+  (setf (driver-initialized driver) t))
+
+(defmethod driver-shutdown ((driver postmodern-postgresql-driver) &key)
+  (log:debug "[POSTMODERN-PGSQL] Shutting down ~A driver" (driver-name driver))
+  (pomo:disconnect-toplevel)
+  (setf (driver-initialized driver) nil))
+
+(defmethod driver-list-applied ((driver postmodern-postgresql-driver)
+                                &key (offset 0) (limit 100))
+  (log:debug "[POSTMODERN-PGSQL] Fetching list of applied migrations")
+  (let* ((query (format nil "SELECT * FROM migration ORDER BY id DESC LIMIT ~A OFFSET ~A"
+                        limit offset))
+         (rows (pomo:query query)))
+    (mapcar (lambda (row)
+              (destructuring-bind (id kind description applied)
+                  row;;might have to clean things 
+                (make-instance 'base-migration
+                               :id id 
+                               :kind (intern kind :keyword)
+                               :description description
+                               :applied applied)))
+            rows)))
+
+(defmethod driver-register-migration ((direction (eql :up))
+                                      (driver postmodern-postgresql-driver)
+                                      migration &key)
+  (log:debug "[POSTMODERN-PGSQL] Registering migration as successful: ~a"
+             (migration-id migration))
+  (with-accessors ((id migration-id)
+                   (description migration-description)
+                   (kind migration-kind))
+      migration
+    (let ((query (format nil "INSERT INTO migration (id, description, kind) ~
+                              VALUES (~A, '~A', '~A')" id description kind)))
+      (pomo:with-transaction ()
+          (pomo:query query)))))
+
+(defmethod driver-register-migration ((direction (eql :down)) (driver postmodern-postgresql-driver)
+                                      migration &key)
+  (log:debug "[POSTMODERN-PGSQL] Unregistering migration: ~A" (migration-id migration))
+    (with-accessors ((id migration-id))
+        migration                      
+      (let ((query (format nil "DELETE FROM migration WHERE id = ~A" id)))
+        (pomo:with-transaction ()
+            (pomo:query query)))))
+
+(defmethod driver-apply-migration ((direction (eql :up)) (kind (eql :sql))
+                                   (driver postmodern-postgresql-driver) migration &key)
+  (%postmodern-postgresql-driver-apply-migration direction driver migration))
+
+(defmethod driver-apply-migration ((direction (eql :down)) (kind (eql :sql))
+                                   (driver postmodern-postgresql-driver) migration &key)
+  (%postmodern-postgresql-driver-apply-migration direction driver migration))
+
+(defun make-driver (provider connection-specification)
+  "Creates a driver for performing migrations against a SQL database
+
+Arguments:
+
+  - provider: an instance of a provider (e.g. local-path)
+  - connection-specification: a connection specification as required by hu.dwim.postmodern e.g. (:host \"localhost\" :port 5432 :database \"migratum\" :user-name \"migratum_user\" :password \"changeit\" :use-ssl :yes)
+    Note that :host defaults to \"localhost\", :port to 5432, and :use-ssl to :no"
+  (make-instance 'postmodern-postgresql-driver
+                 :name "POSTMODERN-PG"
+                 :provider provider
+                 :connection-specification connection-specification))
+
+(defun %postmodern-postgresql-driver-apply-migration (direction driver migration)
+  "Applies the script loaded using the migration script loader function"
+  (with-accessors ((id migration-id)
+                   (description migration-description)
+                   (kind migration-kind))
+      migration 
+    (let* ((content (migration-load direction migration))
+           (statements (str:split *sql-statement-separator* content :omit-nulls t)))
+      (log:debug "[POSTMODERN-PGSQL] Applying ~A migration: ~A - ~A (~A)"
+                 direction id description kind)
+      (pomo:with-transaction ()
+          (dolist (statement statements)
+            (let ((stmt (string-trim #(#\Newline) statement)))
+              (pomo:query stmt)))))))

--- a/t/postmodern-postgresql-driver.lisp
+++ b/t/postmodern-postgresql-driver.lisp
@@ -1,0 +1,119 @@
+;; Copyright (c) 2020-2022 Marin Atanasov Nikolov <dnaeon@gmail.com>
+;; Copyright (c) 2022 Kambiz Darabi <darabi@m-creations.net>
+;; All rights reserved.
+;;
+;; Redistribution and use in source and binary forms, with or without
+;; modification, are permitted provided that the following conditions
+;; are met:
+;;
+;;  1. Redistributions of source code must retain the above copyright
+;;     notice, this list of conditions and the following disclaimer
+;;     in this position and unchanged.
+;;  2. Redistributions in binary form must reproduce the above copyright
+;;     notice, this list of conditions and the following disclaimer in the
+;;     documentation and/or other materials provided with the distribution.
+;;
+;; THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+;; IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+;; OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+;; IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+;; INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+;; NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+;; DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+;; THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+;; (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+;; THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+(in-package :cl-migratum.test)
+
+(deftest postmodern-postgresql-driver
+  (testing "driver-initialized"
+    (ok (eq nil (driver-initialized *postmodern-postgresql-driver*)) "driver is not yet initialized"))
+
+  (testing "driver-init"
+    (ok (eq t (driver-init *postmodern-postgresql-driver*)) "initialize driver")
+    (ok (eq t (driver-initialized *postmodern-postgresql-driver*)) "driver is initialized"))
+
+  (testing "driver-list-applied"
+    (ng (driver-list-applied *postmodern-postgresql-driver*) "no migrations have been applied yet"))
+
+  (testing "contains-applied-migrations-p"
+    (ok (eq nil (contains-applied-migrations-p *postmodern-postgresql-driver*)) "does not contain applied migrations"))
+
+  (testing "list-pending"
+    (let ((pending (list-pending *postmodern-postgresql-driver*)))
+      (ok (= 5 (length pending)) "number of pending migrations matches")
+      (ok (equal (list 20200421173657   ;; SQL
+                       20200421173908   ;; SQL
+                       20200421180337   ;; SQL
+                       20200605144633   ;; SQL
+                       20220327224455)  ;; Lisp
+                 (mapcar #'migration-id pending))
+          "identifiers of pending migrations matches")
+      (ok (equal (list :sql :sql :sql :sql :lisp)
+                 (mapcar #'migration-kind pending))
+          "migration kinds match")))
+
+  (testing "apply-pending"
+    (apply-pending *postmodern-postgresql-driver*)
+    (let ((applied (driver-list-applied *postmodern-postgresql-driver*)))
+      (ok (= 5 (length applied)) "number of applied migrations matches")
+      (ok (equal (list  20220327224455   ;; Lisp
+                        20200605144633   ;; SQL
+                        20200421180337   ;; SQL
+                        20200421173908   ;; SQL
+                        20200421173657)  ;; SQL
+                 (mapcar #'migration-id applied))
+          "identifiers of applied migrations matches")
+      (ok (equal (list :lisp :sql :sql :sql :sql)
+                 (mapcar #'migration-kind applied))
+          "migration kinds match")))
+
+  (testing "pagination"
+    (ok (= 1 (length (driver-list-applied *postmodern-postgresql-driver* :offset 0 :limit 1)))
+        "page with :offset 0 :limit 1")
+    (ok (= 1 (length (driver-list-applied *postmodern-postgresql-driver* :offset 1 :limit 1)))
+        "page with :offset 1 :limit 1")
+    (ok (= 2 (length (driver-list-applied *postmodern-postgresql-driver* :offset 1 :limit 2)))
+        "page with :offset 1 :limit 2")
+
+    ;; We don't have that many test migrations, but if we do -- make
+    ;; sure to adjust the numbers.
+    (ng (driver-list-applied *postmodern-postgresql-driver* :offset 100 :limit 100)
+        "page with :offset 100 :limit 100"))
+
+  (testing "latest-migration"
+    (ok (= 20220327224455 (migration-id (latest-migration *postmodern-postgresql-driver*)))
+        "latest migration id matches"))
+
+  (testing "revert-last"
+    (revert-last *postmodern-postgresql-driver* :count 5)
+    (ng (contains-applied-migrations-p *postmodern-postgresql-driver*)
+        "no migrations present after revert")
+    (ng (driver-list-applied *postmodern-postgresql-driver*)
+        "no migrations applied after revert"))
+
+  (testing "apply-next"
+    (ng (contains-applied-migrations-p *postmodern-postgresql-driver*)
+        "no migrations present yet")
+    (apply-next *postmodern-postgresql-driver*)
+    (ok (= 20200421173657 (migration-id (latest-migration *postmodern-postgresql-driver*)))
+        "id matches next applied migration")
+    (apply-next *postmodern-postgresql-driver*)
+    (ok (= 20200421173908 (migration-id (latest-migration *postmodern-postgresql-driver*)))
+        "id matches next applied migration")
+    (apply-next *postmodern-postgresql-driver*)
+    (ok (= 20200421180337 (migration-id (latest-migration *postmodern-postgresql-driver*)))
+        "id matches next applied migration")
+    (apply-next *postmodern-postgresql-driver*)
+    (ok (= 20200605144633 (migration-id (latest-migration *postmodern-postgresql-driver*)))
+        "id matches next applied migration")
+    (apply-next *postmodern-postgresql-driver*)
+    (ok (= 20220327224455 (migration-id (latest-migration *postmodern-postgresql-driver*)))
+        "id matches next applied migration")
+
+    ;; No more pending migrations at this point
+    ;; ID did not change, since last migration
+    (apply-next *postmodern-postgresql-driver*)
+    (ok (= 20220327224455 (migration-id (latest-migration *postmodern-postgresql-driver*)))
+        "id of last migration is the same")))

--- a/t/test-suite.lisp
+++ b/t/test-suite.lisp
@@ -83,15 +83,15 @@
 
 (defparameter *rdbms-postgresql-port*
   5432
-  "Listening port for Postmoderns test PostgreSQL instance.")
+  "Listening port for RDBM's test PostgreSQL instance.")
 
 (defparameter *postmodern-postgresql-driver*
   nil
   "Driver from library pomo for PostgreSQL")
 
-(defparameter *rdbms-postgresql-port*
+(defparameter *postmodern-postgresql-port*
   5433
-  "Listening port for RDBM's test PostgreSQL instance.")
+  "Listening port for Postmoderns test PostgreSQL instance.")
 
 (defparameter *provider*
   nil
@@ -115,7 +115,7 @@
     (setf *postmodern-postgresql-driver*
           (migratum.driver.postmodern-postgresql:make-driver
            *provider*
-           (list* :port *postmodern-postgresql-port auth))
+           (list* :port *postmodern-postgresql-port* auth))
           *rdbms-postgresql-driver*
           (migratum.driver.rdbms-postgresql:make-driver
            *provider*

--- a/t/test-suite.lisp
+++ b/t/test-suite.lisp
@@ -81,9 +81,17 @@
   nil
   "Driver from library hu.dwim.rdbms for PostgreSQL")
 
+(defparameter *rdbms-postgresql-port*
+  5432
+  "Listening port for Postmoderns test PostgreSQL instance.")
+
 (defparameter *postmodern-postgresql-driver*
   nil
   "Driver from library pomo for PostgreSQL")
+
+(defparameter *rdbms-postgresql-port*
+  5433
+  "Listening port for RDBM's test PostgreSQL instance.")
 
 (defparameter *provider*
   nil
@@ -105,11 +113,14 @@
             :user-name ,(or (uiop:getenv "PGUSER") "migratum")
             :password ,(or (uiop:getenv "PGPASSWORD") "FvbRd5qdeWHNum9p"))))
     (setf *postmodern-postgresql-driver*
-          (migratum.driver.postmodern-postgresql:make-driver *provider* auth)
+          (migratum.driver.postmodern-postgresql:make-driver
+           *provider*
+           (list* :port *postmodern-postgresql-port auth))
           *rdbms-postgresql-driver*
-          (migratum.driver.rdbms-postgresql:make-driver *provider* auth))))
-                          
-
+          (migratum.driver.rdbms-postgresql:make-driver
+           *provider*
+           (list* :port *rdbms-postgresql-port* auth)))))
+                         
 (teardown
   (provider-shutdown *provider*)
   (driver-shutdown *dbi-driver*)


### PR DESCRIPTION
Hi, I have created a driver for postgres that uses Postmodern.
There isn't much difference between this and the rdbms version, I just  dont want to pull in more dependencies to run migrations on my project when I already have Postmodern.
