### PR TITLE
Provide facility to install the cli util via roswell

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,13 @@ The following systems are available as part of this repo.
 
 ## Installation
 
-Latest development version can be installed from the Git repo.
+Installation is possible via [roswell](https://github.com/roswell/roswell). This will also build the `migratum` binary (see section CLI):
+
+``` shell
+ros install cl-migratum
+```
+
+The latest development version can be installed from the Git repo.
 
 Clone the [cl-migratum](https://github.com/dnaeon/cl-migratum) repo in your
 [Quicklisp local-projects directory](https://www.quicklisp.org/beta/faq.html).

--- a/cl-migratum.asd
+++ b/cl-migratum.asd
@@ -18,6 +18,7 @@
   :depends-on (:local-time
                :cl-ascii-table
                :cl-reexport
+               :uiop
                :log4cl)
   :components ((:module "util"
                 :pathname #P"src/"

--- a/roswell/migratum.ros
+++ b/roswell/migratum.ros
@@ -1,0 +1,19 @@
+#!/bin/sh
+#|-*- mode:lisp -*-|#
+#|
+exec ros -Q -- $0 "$@"
+|#
+(progn ;;init forms
+  (ros:ensure-asdf)
+  #+quicklisp(ql:quickload '(:cl-migratum.cli) :silent t)
+  )
+
+(defpackage :ros.script.migratum.3910874952
+  (:use :cl))
+
+(in-package :ros.script.migratum.3910874952)
+
+(defun main (&rest argv)
+  (declare (ignorable argv))
+  (cl-migratum.cli:main argv))
+;;; vim: set ft=lisp lisp:

--- a/src/cli/main.lisp
+++ b/src/cli/main.lisp
@@ -172,7 +172,7 @@
    :handler #'top-level/handler
    :pre-hook #'top-level/pre-hook))
 
-(defun main ()
+(defun main (&optional argv)
   "Main CLI entrypoint"
   (let ((app (top-level/command)))
-    (clingon:run app)))
+    (clingon:run app argv)))

--- a/src/cli/package.lisp
+++ b/src/cli/package.lisp
@@ -24,7 +24,7 @@
 ;; THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 (in-package :cl-user)
-(defpackage :cl-migratum.cli
+(uiop:define-package :cl-migratum.cli
   (:use :cl)
   (:nicknames :migratum.cli)
   (:import-from :clingon)

--- a/src/core.lisp
+++ b/src/core.lisp
@@ -24,7 +24,7 @@
 ;; THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 (in-package :cl-user)
-(defpackage :cl-migratum.core
+(uiop:define-package :cl-migratum.core
   (:use :cl)
   (:nicknames :migratum.core)
   (:import-from :ascii-table)

--- a/src/driver/dbi.lisp
+++ b/src/driver/dbi.lisp
@@ -24,7 +24,7 @@
 ;; THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 (in-package :cl-user)
-(defpackage :cl-migratum.driver.dbi
+(uiop:define-package :cl-migratum.driver.dbi
   (:use :cl)
   (:nicknames :migratum.driver.dbi)
   (:import-from

--- a/src/driver/mixins/mixins.lisp
+++ b/src/driver/mixins/mixins.lisp
@@ -24,7 +24,7 @@
 ;; THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 (in-package :cl-user)
-(defpackage :cl-migratum.driver.mixins
+(uiop:define-package :cl-migratum.driver.mixins
   (:nicknames :migratum.driver.mixins)
   (:use :cl)
   (:import-from

--- a/src/driver/postmodern-postgresql.lisp
+++ b/src/driver/postmodern-postgresql.lisp
@@ -25,7 +25,7 @@
 ;; THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 (in-package :cl-user)
-(defpackage :cl-migratum.driver.postmodern-postgresql
+(uiop:define-package :cl-migratum.driver.postmodern-postgresql
   (:use :cl)
   (:nicknames :migratum.driver.postmodern-postgresql)
   (:import-from
@@ -90,7 +90,7 @@ CREATE TABLE IF NOT EXISTS migration (
 (defmethod driver-init ((driver postmodern-postgresql-driver) &key)
   (log:debug "[POSTMODERN-PGSQL] Initializing ~A driver" (driver-name driver))
   (pomo:with-transaction ()
-      (pomo:query *sql-init-schema*))
+    (pomo:query *sql-init-schema*))
   (setf (driver-initialized driver) t))
 
 (defmethod driver-shutdown ((driver postmodern-postgresql-driver) &key)
@@ -126,16 +126,16 @@ CREATE TABLE IF NOT EXISTS migration (
     (let ((query (format nil "INSERT INTO migration (id, description, kind) ~
                               VALUES (~A, '~A', '~A')" id description kind)))
       (pomo:with-transaction ()
-          (pomo:query query)))))
+        (pomo:query query)))))
 
 (defmethod driver-register-migration ((direction (eql :down)) (driver postmodern-postgresql-driver)
                                       migration &key)
   (log:debug "[POSTMODERN-PGSQL] Unregistering migration: ~A" (migration-id migration))
-    (with-accessors ((id migration-id))
-        migration                      
-      (let ((query (format nil "DELETE FROM migration WHERE id = ~A" id)))
-        (pomo:with-transaction ()
-            (pomo:query query)))))
+  (with-accessors ((id migration-id))
+      migration
+    (let ((query (format nil "DELETE FROM migration WHERE id = ~A" id)))
+      (pomo:with-transaction ()
+        (pomo:query query)))))
 
 (defmethod driver-apply-migration ((direction (eql :up)) (kind (eql :sql))
                                    (driver postmodern-postgresql-driver) migration &key)
@@ -169,6 +169,6 @@ Arguments:
       (log:debug "[POSTMODERN-PGSQL] Applying ~A migration: ~A - ~A (~A)"
                  direction id description kind)
       (pomo:with-transaction ()
-          (dolist (statement statements)
-            (let ((stmt (string-trim #(#\Newline) statement)))
-              (pomo:query stmt)))))))
+        (dolist (statement statements)
+          (let ((stmt (string-trim #(#\Newline) statement)))
+            (pomo:query stmt)))))))

--- a/src/driver/rdbms-postgresql.lisp
+++ b/src/driver/rdbms-postgresql.lisp
@@ -25,7 +25,7 @@
 ;; THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 (in-package :cl-user)
-(defpackage :cl-migratum.driver.rdbms-postgresql
+(uiop:define-package :cl-migratum.driver.rdbms-postgresql
   (:use :cl)
   (:nicknames :migratum.driver.rdbms-postgresql)
   (:import-from
@@ -47,7 +47,7 @@
   (:import-from :log)
   (:import-from :hu.dwim.logger
    :+warn+
-   :set-log-level)
+                :set-log-level)
   (:import-from :hu.dwim.rdbms.postgresql)
   (:import-from :cl-ppcre)
   (:export
@@ -96,7 +96,7 @@ CREATE TABLE IF NOT EXISTS migration (
          (query *sql-init-schema*))
     (hu.dwim.rdbms:with-database database
       (hu.dwim.rdbms:with-transaction
-        (hu.dwim.rdbms:execute query)))
+          (hu.dwim.rdbms:execute query)))
     (setf (driver-initialized driver) t)))
 
 (defmethod driver-shutdown ((driver rdbms-postgresql-driver) &key)
@@ -126,7 +126,7 @@ CREATE TABLE IF NOT EXISTS migration (
          (query (format nil "INSERT INTO migration (id, description, kind) VALUES (~A, '~A', '~A')" id description kind)))
     (hu.dwim.rdbms:with-database db
       (hu.dwim.rdbms:with-transaction
-        (hu.dwim.rdbms:execute query)))))
+          (hu.dwim.rdbms:execute query)))))
 
 (defmethod driver-register-migration ((direction (eql :down)) (driver rdbms-postgresql-driver)
                                       migration &key)
@@ -136,7 +136,7 @@ CREATE TABLE IF NOT EXISTS migration (
          (query (format nil "DELETE FROM migration WHERE id = ~A" id)))
     (hu.dwim.rdbms:with-database db
       (hu.dwim.rdbms:with-transaction
-        (hu.dwim.rdbms:execute query)))))
+          (hu.dwim.rdbms:execute query)))))
 
 (defmethod driver-apply-migration ((direction (eql :up)) (kind (eql :sql))
                                    (driver rdbms-postgresql-driver) migration &key)
@@ -170,6 +170,6 @@ Arguments:
     (log:debug "[RDBMS-PGSQL] Applying ~A migration: ~A - ~A (~A)" direction id description kind)
     (hu.dwim.rdbms:with-database db
       (hu.dwim.rdbms:with-transaction
-        (dolist (statement statements)
-          (let ((stmt (string-trim #(#\Newline) statement)))
-            (hu.dwim.rdbms:execute stmt)))))))
+          (dolist (statement statements)
+            (let ((stmt (string-trim #(#\Newline) statement)))
+              (hu.dwim.rdbms:execute stmt)))))))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -24,7 +24,7 @@
 ;; THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 (in-package :cl-user)
-(defpackage :cl-migratum
+(uiop:define-package :cl-migratum
   (:nicknames :migratum)
   (:use :cl))
 (in-package :cl-migratum)

--- a/src/provider/local-path.lisp
+++ b/src/provider/local-path.lisp
@@ -24,7 +24,7 @@
 ;; THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 (in-package :cl-user)
-(defpackage :cl-migratum.provider.local-path
+(uiop:define-package :cl-migratum.provider.local-path
   (:use :cl)
   (:nicknames :migratum.provider.local-path)
   (:import-from :log)
@@ -188,16 +188,16 @@ discovered from the given PATHS."
   "Groups migration files by id. Each group consists of the upgrade and downgrade scripts."
   (reduce (lambda (acc file)
             (cl-ppcre:register-groups-bind (id description direction extension)
-                (scanner (namestring file))
-              (let* ((id (parse-integer id))
-                     (group (gethash id acc nil)))
-                (setf (gethash id acc)
-                      (push (list :id id
-                                  :direction direction
-                                  :description description
-                                  :path file
-                                  :extension extension)
-                            group))))
+                                           (scanner (namestring file))
+                                           (let* ((id (parse-integer id))
+                                                  (group (gethash id acc nil)))
+                                             (setf (gethash id acc)
+                                                   (push (list :id id
+                                                               :direction direction
+                                                               :description description
+                                                               :path file
+                                                               :extension extension)
+                                                         group))))
             acc)
           files
           :initial-value (make-hash-table :test #'equal)))

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -24,7 +24,7 @@
 ;; THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 (in-package :cl-user)
-(defpackage :cl-migratum.util
+(uiop:define-package :cl-migratum.util
   (:use :cl)
   (:nicknames :migratum.util)
   (:export

--- a/t/20220327224455-migration.lisp
+++ b/t/20220327224455-migration.lisp
@@ -24,7 +24,7 @@
 ;; THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 (in-package :cl-user)
-(defpackage :cl-migratum.test.20220327224455
+(uiop:define-package :cl-migratum.test.20220327224455
   (:use :cl)
   (:import-from :cl-dbi)
   (:import-from :cl-migratum.driver.dbi)
@@ -91,7 +91,7 @@
     (hu.dwim.rdbms:with-database db
       ;; Create the schema and populate it with some data
       (hu.dwim.rdbms:with-transaction
-        (hu.dwim.rdbms:execute schema)
+          (hu.dwim.rdbms:execute schema)
         (loop :for i :from 1 :to 42
               :for name = (format nil "name-~A" i)
               :for value = (+ i 42) :do
@@ -103,25 +103,24 @@
         (query "DROP TABLE lisp_code_table"))
     (hu.dwim.rdbms:with-database db
       (hu.dwim.rdbms:with-transaction
-        (hu.dwim.rdbms:execute query)))))
+          (hu.dwim.rdbms:execute query)))))
 
 (defun %pomo-pgsql-apply-up (driver)
   "POMO-POSTGRESQL upgrade handler for migration id 20220327224455"
   (declare (ignore driver))
   (let ((schema *table-schema*)
         (populate-stmt "INSERT INTO lisp_code_table (id, name, value) VALUES (~A, '~A', ~A)"))
-      ;; Create the schema and populate it with some data
-      (pomo:with-transaction ()
-        (pomo:query schema)
-        (loop :for i :from 1 :to 42
-              :for name = (format nil "name-~A" i)
-              :for value = (+ i 42) :do
-                (pomo:query (format nil populate-stmt i name value))))))
+    ;; Create the schema and populate it with some data
+    (pomo:with-transaction ()
+      (pomo:query schema)
+      (loop :for i :from 1 :to 42
+            :for name = (format nil "name-~A" i)
+            :for value = (+ i 42) :do
+              (pomo:query (format nil populate-stmt i name value))))))
 
 (defun %pomo-pgsql-apply-down (driver)
   "POMO-POSTGRESQL downgrade handler for migration id 20220327224455"
   (declare (ignore driver))
   (let ((query "DROP TABLE lisp_code_table"))
-      (pomo:with-transaction ()
-        (pomo:query query))))
-
+    (pomo:with-transaction ()
+      (pomo:query query))))

--- a/t/test-suite.lisp
+++ b/t/test-suite.lisp
@@ -24,7 +24,7 @@
 ;; THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 (in-package :cl-user)
-(defpackage :cl-migratum.test
+(uiop:define-package :cl-migratum.test
   (:use :cl :rove)
   (:nicknames :migratum.test)
   (:import-from :tmpdir)
@@ -101,35 +101,35 @@
         default)))
 
 (setup
-  (setf *tmpdir* (tmpdir:mkdtemp))
-  (setf *sqlite-conn*
-        (cl-dbi:connect :sqlite3
-                        :database-name (merge-pathnames
-                                        (make-pathname :name "cl-migratum" :type "db")
-                                                        *tmpdir*)))
-  (setf *provider* (cl-migratum.provider.local-path:make-provider (list *migrations-path*)))
-  (setf *dbi-driver*
-        (migratum.driver.dbi:make-driver *provider* *sqlite-conn*))
-  (let ((rdbms-auth
-          (list :host (getenv "PGHOST" "localhost")
-                :port (getenv-int "PGPORT" 5432)
-                :database (getenv "RDBMS_DB" "rdbms")
-                :user-name (getenv "RDBMS_USER" "rdbms_user")
-                :password (getenv "RDMBS_PASS" "rdbms_p4ss")))
-        (postmodern-auth
-          (list :host (getenv "PGHOST" "localhost")
-                :port (getenv-int "PGPORT" 5432)
-                :database (getenv "POSTMODERN_DB" "postmodern")
-                :user-name (getenv "POSTMODERN_USER" "postmodern_user")
-                :password (getenv "POSTMODERN_PASS" "postmodern_p4ss"))))
-    (setf *postmodern-postgresql-driver*
-          (migratum.driver.postmodern-postgresql:make-driver *provider* postmodern-auth)
-          *rdbms-postgresql-driver*
-          (migratum.driver.rdbms-postgresql:make-driver *provider* rdbms-auth))))
+ (setf *tmpdir* (tmpdir:mkdtemp))
+ (setf *sqlite-conn*
+       (cl-dbi:connect :sqlite3
+                       :database-name (merge-pathnames
+                                       (make-pathname :name "cl-migratum" :type "db")
+                                       *tmpdir*)))
+ (setf *provider* (cl-migratum.provider.local-path:make-provider (list *migrations-path*)))
+ (setf *dbi-driver*
+       (migratum.driver.dbi:make-driver *provider* *sqlite-conn*))
+ (let ((rdbms-auth
+         (list :host (getenv "PGHOST" "localhost")
+               :port (getenv-int "PGPORT" 5432)
+               :database (getenv "RDBMS_DB" "rdbms")
+               :user-name (getenv "RDBMS_USER" "rdbms_user")
+               :password (getenv "RDMBS_PASS" "rdbms_p4ss")))
+       (postmodern-auth
+         (list :host (getenv "PGHOST" "localhost")
+               :port (getenv-int "PGPORT" 5432)
+               :database (getenv "POSTMODERN_DB" "postmodern")
+               :user-name (getenv "POSTMODERN_USER" "postmodern_user")
+               :password (getenv "POSTMODERN_PASS" "postmodern_p4ss"))))
+   (setf *postmodern-postgresql-driver*
+         (migratum.driver.postmodern-postgresql:make-driver *provider* postmodern-auth)
+         *rdbms-postgresql-driver*
+         (migratum.driver.rdbms-postgresql:make-driver *provider* rdbms-auth))))
 
 (teardown
-  (provider-shutdown *provider*)
-  (driver-shutdown *dbi-driver*)
-  (driver-shutdown *postmodern-postgresql-driver*)
-  (when *tmpdir*
-    (uiop:delete-directory-tree *tmpdir* :validate t)))
+ (provider-shutdown *provider*)
+ (driver-shutdown *dbi-driver*)
+ (driver-shutdown *postmodern-postgresql-driver*)
+ (when *tmpdir*
+   (uiop:delete-directory-tree *tmpdir* :validate t)))


### PR DESCRIPTION
Added a script to install the cli util via roswell when using `ros install cl-migratum`. 
Changed the non-asd occurrences of defpackage to uiop:define-package to avoid compile errors on sbcl, due to changing package variance.
Added README information. 